### PR TITLE
Make product cards navigate to product details

### DIFF
--- a/src/components/product-card.tsx
+++ b/src/components/product-card.tsx
@@ -1,11 +1,9 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import type { Product } from '@/lib/types';
+import type { Product, ProductVariant } from '@/lib/types';
 import { profiles } from '@/data/profiles';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -21,6 +19,7 @@ interface ProductCardProps {
 
 export function ProductCard({ product }: ProductCardProps) {
   const router = useRouter();
+  const cardHref = `/products/${product.id}`;
   const isSambatan = product.sambatan?.isActive;
   const { toggleWishlist, isInWishlist } = useWishlist();
   const sellerProfile = profiles.find(p => p.slug === product.perfumerProfileSlug);
@@ -29,17 +28,45 @@ export function ProductCard({ product }: ProductCardProps) {
   // Client-side check to avoid hydration mismatch
   const inWishlist = isInWishlist(product.id);
 
+  const navigateToSeller = () => {
+    if (!sellerProfile?.slug) return;
+    router.push(`/browse?seller=${sellerProfile.slug}`);
+  };
+
   const handleWishlistClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     toggleWishlist(product);
-  }
+  };
 
   const handleSellerClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation(); // Prevents the main card link from firing
-    router.push(`/browse?seller=${sellerProfile?.slug}`);
-  }
+    navigateToSeller();
+  };
+
+  const handleSellerKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      navigateToSeller();
+    }
+  };
+
+  const handleNavigateToDetail = (event?: React.MouseEvent<HTMLDivElement>) => {
+    if (event?.metaKey || event?.ctrlKey) {
+      window.open(cardHref, '_blank');
+      return;
+    }
+    router.push(cardHref);
+  };
+
+  const handleCardKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleNavigateToDetail();
+    }
+  };
 
   const priceDisplay = () => {
     if (product.sambatan?.isActive) {
@@ -53,68 +80,72 @@ export function ProductCard({ product }: ProductCardProps) {
   };
 
   return (
-    <Link href={`/products/${product.id}`} className="block h-full">
-      <Card className="group relative flex h-full transform-gpu flex-col overflow-hidden rounded-2xl border-none bg-transparent shadow-neumorphic transition-all duration-300 ease-in-out hover:-translate-y-1 hover:shadow-lg">
-        <CardHeader className="relative p-0">
-          <div className="relative w-full aspect-square">
-            <Image
-              src={product.imageUrl}
-              alt={product.name}
-              fill
-              className="object-cover transition-transform duration-300 group-hover:scale-105"
-              data-ai-hint={product.imageHint}
-            />
-             {isSambatan && (
-                <Badge className="absolute top-2 right-2 bg-accent-gradient text-accent-foreground">
-                  <Users className="mr-1.5 h-3 w-3" />
-                  Sambatan
-                </Badge>
-            )}
-            {!isSambatan && (
-              <Button
-                size="icon"
-                variant="ghost"
-                className="absolute top-2 right-2 h-9 w-9 rounded-full bg-background/70 shadow-neumorphic backdrop-blur-sm transition-all hover:bg-background"
-                onClick={handleWishlistClick}
-              >
-                  <Heart className={cn("h-5 w-5 text-muted-foreground", inWishlist && "fill-destructive text-destructive")} />
-              </Button>
-            )}
-             {isCurated && (
-              <div className="absolute bottom-2 left-2 flex items-center gap-1.5 rounded-full bg-blue-100/80 px-2 py-1 text-xs font-semibold text-blue-800 backdrop-blur-sm">
-                <BadgeCheck className="h-4 w-4" />
-                Terverifikasi
-              </div>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent className="flex-grow p-4">
-          <Badge variant="secondary" className="mb-2 rounded-md bg-accent/50 text-accent-foreground">
-            {product.category}
-          </Badge>
-          <CardTitle className="text-lg font-bold text-foreground/90">{product.name}</CardTitle>
-          {sellerProfile && (
-            <div 
-              role="button"
-              tabIndex={0}
-              onClick={handleSellerClick}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleSellerClick(e as any); }}
-              className="mt-1 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-accent hover:underline"
+    <Card
+      role="link"
+      tabIndex={0}
+      onClick={handleNavigateToDetail}
+      onKeyDown={handleCardKeyDown}
+      className="group relative flex h-full cursor-pointer transform-gpu flex-col overflow-hidden rounded-2xl border-none bg-transparent shadow-neumorphic transition-all duration-300 ease-in-out hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+    >
+      <CardHeader className="relative p-0">
+        <div className="relative w-full aspect-square">
+          <Image
+            src={product.imageUrl}
+            alt={product.name}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            data-ai-hint={product.imageHint}
+          />
+          {isSambatan && (
+            <Badge className="absolute top-2 right-2 bg-accent-gradient text-accent-foreground">
+              <Users className="mr-1.5 h-3 w-3" />
+              Sambatan
+            </Badge>
+          )}
+          {!isSambatan && (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="absolute top-2 right-2 h-9 w-9 rounded-full bg-background/70 shadow-neumorphic backdrop-blur-sm transition-all hover:bg-background"
+              onClick={handleWishlistClick}
             >
-              <Store className="h-3.5 w-3.5" />
-              {sellerProfile.name}
+              <Heart className={cn("h-5 w-5 text-muted-foreground", inWishlist && "fill-destructive text-destructive")} />
+            </Button>
+          )}
+          {isCurated && (
+            <div className="absolute bottom-2 left-2 flex items-center gap-1.5 rounded-full bg-blue-100/80 px-2 py-1 text-xs font-semibold text-blue-800 backdrop-blur-sm">
+              <BadgeCheck className="h-4 w-4" />
+              Terverifikasi
             </div>
           )}
-          <CardDescription className="mt-2 text-sm text-muted-foreground line-clamp-2">
-            {product.description}
-          </CardDescription>
-        </CardContent>
-        <CardFooter className="flex items-center justify-between p-4 pt-0">
-          <p className={cn("text-lg font-bold", isSambatan ? "text-accent" : "text-foreground/80")}>
-            {priceDisplay()}
-          </p>
-        </CardFooter>
-      </Card>
-    </Link>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-grow p-4">
+        <Badge variant="secondary" className="mb-2 rounded-md bg-accent/50 text-accent-foreground">
+          {product.category}
+        </Badge>
+        <CardTitle className="text-lg font-bold text-foreground/90">{product.name}</CardTitle>
+        {sellerProfile && (
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={handleSellerClick}
+            onKeyDown={handleSellerKeyDown}
+            className="mt-1 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-accent hover:underline"
+          >
+            <Store className="h-3.5 w-3.5" />
+            {sellerProfile.name}
+          </div>
+        )}
+        <CardDescription className="mt-2 text-sm text-muted-foreground line-clamp-2">
+          {product.description}
+        </CardDescription>
+      </CardContent>
+      <CardFooter className="flex items-center justify-between p-4 pt-0">
+        <p className={cn("text-lg font-bold", isSambatan ? "text-accent" : "text-foreground/80")}>
+          {priceDisplay()}
+        </p>
+      </CardFooter>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- make the product card itself navigate to the product detail page using the router
- keep wishlist and seller shortcuts working by stopping event propagation where needed
- add keyboard activation and ctrl/cmd-click handling so the card behaves like an accessible link

## Testing
- pnpm lint *(fails: command prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68da0bf030c48327b96b874095957ba3